### PR TITLE
Checking Type of RR in AnswerSection to only print QType

### DIFF
--- a/usages/get-ip.pl
+++ b/usages/get-ip.pl
@@ -46,7 +46,7 @@ foreach my $URL (@DNS_LG_SERVERS) {
 
     my $datos = decode_json $response->{content};
     foreach my $rr (@{$datos->{AnswerSection}}) {
-        print $rr->{Address}, ' ';
+        print $rr->{Address}, ' ' if $rr->{Type} eq 'A';
     }
     print "\n";
 }


### PR DESCRIPTION
Was seeing these errors when the response included other RR types like CNAMEs:

Use of uninitialized value in print at ./get-ip.pl line 49.
